### PR TITLE
Add Linux platform support to notification service

### DIFF
--- a/lib/src/notification/service.dart
+++ b/lib/src/notification/service.dart
@@ -40,8 +40,9 @@ class NotificationService {
       onDidReceiveLocalNotification: _onDidReceiveLocalNotification,
     );
     const macos = DarwinInitializationSettings();
+    const linux = LinuxInitializationSettings(defaultActionName: 'Maily');
     final initSettings =
-        InitializationSettings(android: android, iOS: ios, macOS: macos);
+        InitializationSettings(android: android, iOS: ios, macOS: macos, linux: linux);
     await _flutterLocalNotificationsPlugin.initialize(
       initSettings,
       onDidReceiveNotificationResponse: _selectNotification,

--- a/lib/src/notification/service.dart
+++ b/lib/src/notification/service.dart
@@ -25,7 +25,7 @@ class NotificationService {
 
   Future<NotificationServiceInitResult> init({
     BuildContext? context,
-    bool checkForLaunchDetails = true,
+    bool checkForLaunchDetails = false,
   }) async {
     // print('init notification service...');
     // set up local notifications:


### PR DESCRIPTION
Currently draft because workaround is used for unimplemented function