### PR TITLE
fix: Linux local notifications initialization

### DIFF
--- a/lib/src/notification/service.dart
+++ b/lib/src/notification/service.dart
@@ -44,8 +44,16 @@ class NotificationService {
     const android = AndroidInitializationSettings('ic_stat_notification');
     final ios = DarwinInitializationSettings();
     const macos = DarwinInitializationSettings();
-    final initSettings =
-        InitializationSettings(android: android, iOS: ios, macOS: macos);
+    LinuxInitializationSettings? linux;
+    if (Platform.isLinux) {
+      linux = const LinuxInitializationSettings(defaultActionName: 'Open');
+    }
+    final initSettings = InitializationSettings(
+      android: android,
+      iOS: ios,
+      macOS: macos,
+      linux: linux,
+    );
     await _flutterLocalNotificationsPlugin.initialize(
       initSettings,
       onDidReceiveNotificationResponse: _selectNotification,
@@ -57,7 +65,7 @@ class NotificationService {
               AndroidFlutterLocalNotificationsPlugin>()
           ?.requestNotificationsPermission();
     }
-    if (checkForLaunchDetails) {
+    if (checkForLaunchDetails && !Platform.isLinux) {
       final launchDetails = await _flutterLocalNotificationsPlugin
           .getNotificationAppLaunchDetails();
       if (launchDetails != null && launchDetails.didNotificationLaunchApp) {


### PR DESCRIPTION
Supply LinuxInitializationSettings when running on Linux and skip getNotificationAppLaunchDetails on Linux (matches plugin examples). Fixes crash on desktop Linux.